### PR TITLE
sacloud/makefileへの切り替え

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 vendor/
 dist/
 work/
+go-template

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,17 @@
+# Copyright 2022 The sacloud/go-template Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM golang:1.18 AS builder
 MAINTAINER Usacloud Authors <sacloud.users@gmail.com>
 

--- a/Makefile
+++ b/Makefile
@@ -1,88 +1,14 @@
-AUTHOR                  ?=The sacloud/go-template Authors
-COPYRIGHT_YEAR          ?=2022
-BIN_NAME                ?=go-template
-BIN_DIR                 ?=$(CURDIR)
-GOLANG_CI_LINT_VERSION  ?=v1.46.2
-TEXTLINT_ACTION_VERSION ?=v0.0.1
-
 #====================
-BIN             =$(BIN_DIR)/$(BIN_NAME)
-COPYRIGHT_FILES =$$(find . -name "*.go" -print | grep -v "/vendor/")
+AUTHOR         ?= The sacloud/go-template Authors
+COPYRIGHT_YEAR ?= 2022
+
+BIN            ?= go-template
+GO_FILES       ?= $(shell find . -name '*.go')
+
+DEFAULT_GOALS  ?= fmt set-license go-licenses-check goimports lint test build
+
+include includes/go/common.mk
+include includes/go/single.mk
 #====================
 
-default: fmt set-license go-licenses-check goimports lint test build
-
-.PHONY: install
-install:
-	go install
-
-.PHONY: build
-build: $(BIN)
-
-$(BIN): $(GO_FILES) go.mod go.sum
-	@echo "running 'go build'..."
-	@GOOS=$${OS:-"`go env GOOS`"} GOARCH=$${ARCH:-"`go env GOARCH`"} CGO_ENABLED=0 go build -ldflags=$(BUILD_LDFLAGS) -o $(BIN) main.go
-
-.PHONY: shasum
-shasum: $(BIN)
-	shasum -a 256 $(BIN) > $(BIN_NAME)_SHA256SUMS)
-
-.PHONY: clean
-clean:
-	rm -f $(BIN)
-
-.PHONY: test
-test:
-	@echo "running 'go test'..."
-	TESTACC= go test ./... $(TESTARGS) -v -timeout=120m -parallel=8 -race;
-
-.PHONY: testacc
-testacc:
-	@echo "running 'go test'..."
-	TESTACC=1 go test ./... $(TESTARGS) --tags=acctest -v -timeout=120m -parallel=8 ;
-
-.PHONY: tools
-tools:
-	go install github.com/rinchsan/gosimports/cmd/gosimports@latest
-	go install golang.org/x/tools/cmd/stringer@latest
-	go install github.com/sacloud/addlicense@latest
-	go install github.com/client9/misspell/cmd/misspell@latest
-	go install github.com/google/go-licenses@v1.0.0
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin $(GOLANG_CI_LINT_VERSION)
-
-.PHONY: goimports
-goimports: fmt
-	@echo "running gosimports..."
-	@gosimports -l -w .
-
-.PHONY: fmt
-fmt:
-	@echo "running gofmt..."
-	@find . -name '*.go' | grep -v vendor | xargs gofmt -s -w
-
-.PHONY: godoc
-godoc:
-	godoc -http=localhost:6060
-
-.PHONY: lint lint-go
-lint: lint-go lint-text
-
-.PHONY: lint-go
-lint-go:
-	@echo "running golanci-lint..."
-	@golangci-lint run --fix ./...
-
-.PHONY: textlint lint-text
-textlint: lint-text
-lint-text:
-	@echo "running textlint..."
-	@docker run -it --rm -v $$PWD:/work -w /work ghcr.io/sacloud/textlint-action:$(TEXTLINT_ACTION_VERSION) .
-
-.PHONY: set-license
-set-license:
-	@addlicense -c "$(AUTHOR)" -y "$(COPYRIGHT_YEAR)" $(COPYRIGHT_FILES)
-
-.PHONY: go-licenses-check
-go-licenses-check:
-	@echo "running go-licenses..."
-	@go-licenses check .
+tools: dev-tools

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,9 @@ COPYRIGHT_YEAR ?= 2022
 BIN            ?= go-template
 GO_FILES       ?= $(shell find . -name '*.go')
 
-DEFAULT_GOALS  ?= fmt set-license go-licenses-check goimports lint test build
-
 include includes/go/common.mk
 include includes/go/single.mk
 #====================
 
+default: $(DEFAULT_GOALS)
 tools: dev-tools

--- a/includes/AUTHORS
+++ b/includes/AUTHORS
@@ -1,0 +1,6 @@
+# This is the list of Usacloud authors for copyright purposes.
+#
+# This does not necessarily list everyone who has contributed code, since in
+# some cases, their employer may be the copyright holder.  To see the full list
+# of contributors, see the revision history in source control.
+Kazumichi Yamamoto <yamamoto.febc@gmail.com>

--- a/includes/LICENSE
+++ b/includes/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/includes/README.md
+++ b/includes/README.md
@@ -1,0 +1,51 @@
+# makefile
+
+sacloudプロダクトで共通利用するMakefile
+
+- `go/`: Go言語向け
+
+## Usage
+
+利用するプロジェクト側で以下のように利用します。
+
+#### リモートリポジトリの追加(初回のみ)
+
+```bash
+git remote add makefile https://github.com/sacloud/makefile.git
+```
+
+#### 追加(初回のみ)
+
+```bash
+git subtree add --prefix=includes --squash makefile v0.0.1
+```
+
+利用する側のプロジェクトではMakefileを以下のように記述します。
+
+```makefile
+# 必要に応じて変数定義
+AUTHOR         ?= The sacloud/example Authors
+COPYRIGHT_YEAR ?= 2022
+BIN            ?= example
+DEFAULT_GOALS  ?= fmt set-license go-licenses-check goimports lint test build
+
+# 必要なファイルをインクルード
+include includes/go/common.mk
+include includes/go/simple.mk
+
+# toolsゴールを追加(sacloudプロダクト向け日次CIを行うプロジェクトでは必須)
+tools: dev-tools
+```
+
+#### 更新
+
+```bash
+git subtree pull --prefix=includes --squash makefile v0.0.1
+```
+
+## License
+
+`sacloud/makefile` Copyright (C) 2022 The sacloud/makefile Authors.
+
+This project is published under [Apache 2.0 License](LICENSE).
+

--- a/includes/README.md
+++ b/includes/README.md
@@ -17,7 +17,7 @@ git remote add makefile https://github.com/sacloud/makefile.git
 #### 追加(初回のみ)
 
 ```bash
-git subtree add --prefix=includes --squash makefile v0.0.1
+git subtree add --prefix=includes --squash makefile v0.0.3
 ```
 
 利用する側のプロジェクトではMakefileを以下のように記述します。
@@ -33,14 +33,15 @@ DEFAULT_GOALS  ?= fmt set-license go-licenses-check goimports lint test build
 include includes/go/common.mk
 include includes/go/simple.mk
 
-# toolsゴールを追加(sacloudプロダクト向け日次CIを行うプロジェクトでは必須)
-tools: dev-tools
+# ゴールを追加
+default: $(DEFAULT_GOALS)
+tools: dev-tools # toolsゴールはsacloudプロダクト向け日次CIを行うプロジェクトでは必須
 ```
 
 #### 更新
 
 ```bash
-git subtree pull --prefix=includes --squash makefile v0.0.1
+git subtree pull --prefix=includes --squash makefile v0.0.3
 ```
 
 ## License

--- a/includes/go/common.mk
+++ b/includes/go/common.mk
@@ -1,0 +1,81 @@
+#
+# Copyright 2022 The sacloud/makefile Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+AUTHOR                  ?= The sacloud/makefile Authors
+COPYRIGHT_YEAR          ?= 2022
+COPYRIGHT_FILES         ?= $$(find . -name "*.go" -print | grep -v "/vendor/")
+GO                      ?= go
+DEFAULT_GOALS           ?= fmt set-license go-licenses-check goimports lint test
+GOLANG_CI_LINT_VERSION  ?= v1.46.2
+TEXTLINT_ACTION_VERSION ?= v0.0.1
+
+default: $(DEFAULT_GOALS)
+
+.PHONY: test
+test:
+	@echo "running 'go test'..."
+	TESTACC= $(GO) test ./... $(TESTARGS) -v -timeout=120m -parallel=8 -race;
+
+.PHONY: testacc
+testacc:
+	@echo "running 'go test' with TESTACC=1..."
+	TESTACC=1 $(GO) test ./... $(TESTARGS) --tags=acctest -v -timeout=120m -parallel=8 ;
+
+.PHONY: dev-tools
+dev-tools:
+	$(GO) install github.com/rinchsan/gosimports/cmd/gosimports@latest
+	$(GO) install golang.org/x/tools/cmd/stringer@latest
+	$(GO) install github.com/sacloud/addlicense@latest
+	$(GO) install github.com/client9/misspell/cmd/misspell@latest
+	$(GO) install github.com/google/go-licenses@v1.0.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin $(GOLANG_CI_LINT_VERSION)
+
+.PHONY: goimports
+goimports: fmt
+	@echo "running gosimports..."
+	@gosimports -l -w .
+
+.PHONY: fmt
+fmt:
+	@echo "running gofmt..."
+	@find . -name '*.go' | grep -v vendor | xargs gofmt -s -w
+
+.PHONY: godoc
+godoc:
+	godoc -http=localhost:6060
+
+.PHONY: lint lint-go
+lint: lint-go lint-text
+
+.PHONY: lint-go
+lint-go:
+	@echo "running golanci-lint..."
+	@golangci-lint run --fix ./...
+
+.PHONY: textlint lint-text
+textlint: lint-text
+lint-text:
+	@echo "running textlint..."
+	@docker run -it --rm -v $$PWD:/work -w /work ghcr.io/sacloud/textlint-action:$(TEXTLINT_ACTION_VERSION) .
+
+.PHONY: set-license
+set-license:
+	@addlicense -c "$(AUTHOR)" -y "$(COPYRIGHT_YEAR)" $(COPYRIGHT_FILES)
+
+.PHONY: go-licenses-check
+go-licenses-check:
+	@echo "running go-licenses..."
+	@go-licenses check .

--- a/includes/go/common.mk
+++ b/includes/go/common.mk
@@ -22,7 +22,7 @@ DEFAULT_GOALS           ?= fmt set-license go-licenses-check goimports lint test
 GOLANG_CI_LINT_VERSION  ?= v1.46.2
 TEXTLINT_ACTION_VERSION ?= v0.0.1
 
-default: $(DEFAULT_GOALS)
+.DEFAULT_GOAL = default
 
 .PHONY: test
 test:

--- a/includes/go/single.mk
+++ b/includes/go/single.mk
@@ -1,0 +1,38 @@
+#
+# Copyright 2022 The sacloud/makefile Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+GO             ?= go
+BIN            ?= TODO_PLEASE_SET_BIN_VARIABLE
+GO_ENTRY_FILE  ?= main.go
+GO_FILES       ?= $(shell find . -name '*.go')
+BUILD_LDFLAGS  ?=
+
+.PHONY: install
+install:
+	@echo "running 'go install'..."
+	$(GO) install
+
+.PHONY: build
+build: $(BIN)
+
+$(BIN): $(GO_FILES) go.mod go.sum
+	@echo "running 'go build'..."
+	@GOOS=$${OS:-"`$(GO) env GOOS`"} GOARCH=$${ARCH:-"`$(GO) env GOARCH`"} CGO_ENABLED=0 $(GO) build -ldflags=$(BUILD_LDFLAGS) -o $(BIN) $(GO_ENTRY_FILE)
+
+.PHONY: clean
+clean:
+	@echo "cleaning..."
+	rm -rf $(BIN)

--- a/includes/go/single.mk
+++ b/includes/go/single.mk
@@ -36,3 +36,5 @@ $(BIN): $(GO_FILES) go.mod go.sum
 clean:
 	@echo "cleaning..."
 	rm -rf $(BIN)
+
+DEFAULT_GOALS += build


### PR DESCRIPTION
- 各プロジェクトのMakefileをsacloud/makefileリポジトリで共通化
- 各プロジェクトからはsubtreeとしてsacloud/makefileを利用
- 各プロジェクトのMakefileで必要な.mkをインクルード