### PR TITLE
textlintをmake lint-text経由で実行するように修正

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,13 +13,21 @@ jobs:
       - name: Unshallow
         run: git fetch --prune --unshallow
 
-      - name: lint a document with textlint
-        uses: sacloud/textlint-action@v0.0.1
-        # with:
-        #   working-directory: .
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+
+      - name: Setup tools
+        run: |
+          make tools
+
+      - name: make lint-text
+        run:  |
+          make lint-text
   lint-go:
     name: lint-go
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/includes/README.md
+++ b/includes/README.md
@@ -17,7 +17,7 @@ git remote add makefile https://github.com/sacloud/makefile.git
 #### 追加(初回のみ)
 
 ```bash
-git subtree add --prefix=includes --squash makefile v0.0.5
+git subtree add --prefix=includes --squash makefile v0.0.6
 ```
 
 利用する側のプロジェクトではMakefileを以下のように記述します。
@@ -41,7 +41,7 @@ tools: dev-tools # toolsゴールはsacloudプロダクト向け日次CIを行�
 #### 更新
 
 ```bash
-git subtree pull --prefix=includes --squash makefile v0.0.5
+git subtree pull --prefix=includes --squash makefile v0.0.6
 ```
 
 ## License

--- a/includes/go/common.mk
+++ b/includes/go/common.mk
@@ -70,7 +70,7 @@ lint-go:
 textlint: lint-text
 lint-text:
 	@echo "running textlint..."
-	@docker run -it --rm -v $$PWD:/work -w /work ghcr.io/sacloud/textlint-action:$(TEXTLINT_ACTION_VERSION) .
+	@docker run -t --rm -v $$PWD:/work -w /work ghcr.io/sacloud/textlint-action:$(TEXTLINT_ACTION_VERSION) .
 
 .PHONY: lint-action
 lint-action:


### PR DESCRIPTION
従来はワークフローにてsacloud/textlint-actionを直接利用していたが、go-templateにおいてはMakefile内でtextlint-actionのバージョンを指定しており、ワークフローファイルに書かれたバージョンと2重管理になっていた。
これを解消するためにmake lint-textを実行するようにすることでMakefile側の記述を正とする。