### PR TITLE
misc updates

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,6 @@ issues:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - depguard
     - errcheck
     - exportloopref
@@ -28,7 +27,6 @@ linters:
     - typecheck
     - unconvert
     - unused
-    - varcheck
     - whitespace
 
   # don't enable:

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-# This is the list of sacloud/iaas-api-go authors for copyright purposes.
+# This is the list of sacloud/go-template authors for copyright purposes.
 #
 # This does not necessarily list everyone who has contributed code, since in
 # some cases, their employer may be the copyright holder.  To see the full list

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.18 AS builder
+FROM golang:1.19 AS builder
 MAINTAINER Usacloud Authors <sacloud.users@gmail.com>
 
 RUN  apt-get update && apt-get -y install \
@@ -30,7 +30,7 @@ ENV CGO_ENABLED 0
 RUN make tools build
 # ======
 
-FROM alpine:3.15
+FROM alpine:3.16
 MAINTAINER Usacloud Authors <sacloud.users@gmail.com>
 
 RUN apk add --no-cache --update ca-certificates

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/sacloud/go-template
 
-go 1.18
+go 1.19


### PR DESCRIPTION
closes #12 
closes #13 

- Dockerfileでのgoベースイメージを1.19へ更新
- Dockerfileでのalpineベースイメージを3.16へ更新
- golangci-lintの非推奨linterを除去
- AUTHORSの記載誤りを修正