### PR TITLE
golangci-lintをv2に更新

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,30 +1,31 @@
+version: "2"
 run:
-  deadline: 10m10s
+  timeout: 10m10s
 
 issues:
-  max-per-linter: 0
+  max-issues-per-linter: 0
   max-same-issues: 0
 
 linters:
-  disable-all: true
+  default: none
   enable:
     - errcheck
-    - exportloopref
     - gocritic
-    - gofmt
-    - goimports
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
     - nakedret
     - nolintlint
-    - typecheck
     - unconvert
     - unused
     - whitespace
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
 
   # don't enable:
   #  - asciicheck

--- a/includes/go/common.mk
+++ b/includes/go/common.mk
@@ -19,7 +19,7 @@ COPYRIGHT_YEAR          ?= 2023
 COPYRIGHT_FILES         ?= $$(find . -name "*.go" -print | grep -v "/vendor/")
 GO                      ?= go
 DEFAULT_GOALS           ?= fmt set-license go-licenses-check goimports lint test
-GOLANG_CI_LINT_VERSION  ?= v1.56.2
+GOLANG_CI_LINT_VERSION  ?= v2.1.6
 TEXTLINT_ACTION_VERSION ?= v0.0.3
 
 .DEFAULT_GOAL = default


### PR DESCRIPTION
Go v1.24ではgolangci-lint v1が動かなくなっているので設定含めてv2に上げる

https://golangci-lint.run/product/migration-guide/