### PR TITLE
CIが動くように微調整

### DIFF
--- a/.tagpr
+++ b/.tagpr
@@ -45,4 +45,4 @@
 [tagpr]
 	vPrefix = true
 	releaseBranch = main
-	versionFile = version.go
+	versionFile = version/version.go

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/sacloud/go-template
 
-go 1.21
+go 1.23


### PR DESCRIPTION
- govulncheck + go1.21でのエラー回避のためにgo 1.23へアップグレード
- tagprが編集するバージョンファイルのパスを修正

前者について、現在のワークフローはgo.modに書かれているgoのバージョンを利用するようになっており、`go 1.21`が指定されている状況です。この状態でgovulncheckを実行すると以下のエラーになります。

```
running govulncheck...
Go: go1.21.13
Scanner: govulncheck@v1.1.4
DB: https://vuln.go.dev/
DB updated: 2025-08-14 18:26:33 +0000 UTC

=== Symbol Results ===

Vulnerability #1: GO-2025-3750
    Inconsistent handling of O_CREATE|O_EXCL on Unix and Windows in os in
    syscall
  More info: https://pkg.go.dev/vuln/GO-2025-3750
  Standard library
    Found in: os@go1.21.13
    Fixed in: os@go1.23.10
    Platforms: windows
    Example traces found:
Error:       #1: version/version.go:18:2: version.init calls fmt.init, which eventually calls os.NewFile
```

これを解消できるminバージョンであるgo 1.23に修正しています。

<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

Fixes #

### このPRはどういう変更を行いますか？

### ドキュメントの変更は必要ですか？
