### PR TITLE
tagpr: use custom major/minorLabels

### DIFF
--- a/.tagpr
+++ b/.tagpr
@@ -46,3 +46,5 @@
 	vPrefix = true
 	releaseBranch = main
 	versionFile = version/version.go
+	majorLabels = sacloud-major
+	minorLabels = sacloud-minor


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

no issue

### このPRはどういう変更を行いますか？

https://github.com/sacloud/iaas-api-go/pull/448 の横展開

dependabotとtagprを併用しているが、現状だとdependabotからのPRによりライブラリとしてのAPIに変更がないのに意図せずマイナーバージョンが上がってしまうという問題がある。

これを解決するためにtagprのmajorLabels/minorLabelsを設定し、メジャー/マイナーバージョンを上げたいときはそれぞれ `sacloud-major`/`sacloud-minor`というタグを明示的に付与する運用に変更する。

これらのタグはorg単位で登録しておき、org配下の全リポジトリで利用可能とする。

### ドキュメントの変更は必要ですか？

no